### PR TITLE
Add missing `catbox-memory` dependency

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -38,6 +38,7 @@
     "agenda": "^0.9.0",
     "async": "^2.0.1",
     "boom": "^3.2.2",
+    "catbox-memory": "^2.0.4",
     "chairo": "^2.2.1",
     "chalk": "^1.1.3",
     "dogwater": "^2.1.0",


### PR DESCRIPTION
Closes https://github.com/franzip/generator-hapi-api-stack/issues/1